### PR TITLE
fix: arxiv URL of Self-supervised-representation-learning-revisited

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ DL-vs-Traditional-CV | 2019 | [1910.13796](https://arxiv.org/abs/1910.13796)
 Federated-Machine-Learning | 2019 | [1902.04885](https://arxiv.org/abs/1902.04885)
 Federated-Learning-At-Scale | 2019 | [1902.01046](https://arxiv.org/abs/1902.01046)
 ML-Stuck-in-a-Rut | 2019 | [HotOS-2019](https://dl.acm.org/doi/pdf/10.1145/3317550.3321441)
-Self-supervised-representation-learning-revisited | 2019 | [1901.09005](https://arixv.org/abs/1901.09005)
+Self-supervised-representation-learning-revisited | 2019 | [1901.09005](https://arxiv.org/abs/1901.09005)
 Momentum-Contrast | 2019 | [1911.05722](https://arxiv.org/abs/1911.05722)
 SimCLR | 2020 | [2002.05079](https://arxiv.org/abs/2002.05079)
 


### PR DESCRIPTION
本来就想看看这篇论文，正好碰上地址错了，顺手修好。我用正则搜过一遍，暂时只发现此处一个错误